### PR TITLE
Do not require blas

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - setuptools
   run:
     - python
-    - blas * openblas
     - cachetools >=1.0.0
     - cgen
     - enum34

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: True  # [py3k]
-  number: 4
+  number: 5
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -24,6 +24,7 @@ requirements:
     - setuptools
   run:
     - python
+    - blas * openblas
     - cachetools >=1.0.0
     - cgen
     - enum34


### PR DESCRIPTION
The `blas * openblas` requirement prevents the latest build (4) from being installed with a simple `conda create -n parcels -c conda-forge parcels` unless `blas=*=openblas` is explicitly given during the installation. 

As we're fine with falling back to the defaults `scipy`, `numpy` et al., we can stop requiring openblas.