### PR TITLE
Update meta.yaml to pin zarr<2.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 30d3d6f8a0ed65f7999e5454d7067bff79822fc877a3350492306e48076f0de0
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - {{ PYTHON }} -m pip install .
@@ -43,7 +43,7 @@ requirements:
     - trajan
     - tqdm
     - xarray >=0.10.8
-    - zarr >=2.11.0
+    - zarr >=2.11.0,<2.18.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/oceanparcels/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 30d3d6f8a0ed65f7999e5454d7067bff79822fc877a3350492306e48076f0de0
+  sha256: 34091ae664dba671b81a9ea1638931c20f04599cfa51ea355690a6552fa08617
 
 build:
   number: 1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR pins zarr to <2.18.0, because the latest 2.18.0 breaks parcels (see Issue in https://github.com/OceanParcels/parcels/issues/1564 and patch at https://github.com/OceanParcels/parcels/pull/1565). 

Pin can hopefully be removed when zarr updates to 3.0

<!--
Please add any other relevant info below:
-->
