### PR TITLE
Exclude zarr v2.18.0 from recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 34091ae664dba671b81a9ea1638931c20f04599cfa51ea355690a6552fa08617
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script:
     - {{ PYTHON }} -m pip install .
@@ -43,7 +43,7 @@ requirements:
     - trajan
     - tqdm
     - xarray >=0.10.8
-    - zarr >=2.11.0,<2.18.0
+    - zarr >=2.11.0,!=2.18.0
 
 test:
   requires:


### PR DESCRIPTION
Pinning zarr to exclude v2.18.0. Note that v2.18.1 works again (see https://github.com/OceanParcels/parcels/issues/1564#issuecomment-2118112806) and https://github.com/OceanParcels/parcels/pull/1567

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This PR fixes #105
<!--
Please add any other relevant info below:
-->
